### PR TITLE
Fix stale state bug when updating deck

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -26,31 +26,43 @@ export default function Home() {
   }, []);
 
   const adicionarCarta = (carta) => {
-    const nome = carta.NOME;
-    const existente = deck.find((c) => c.NOME === nome);
-    const totalCartas = deck.reduce((acc, c) => acc + c.quantidade, 0);
+    setDeck((prev) => {
+      const nome = carta.NOME;
+      const existente = prev.find((c) => c.NOME === nome);
+      const totalCartas = prev.reduce((acc, c) => acc + c.quantidade, 0);
 
-    const ehLocal = (carta.TIPO || "").toLowerCase().includes("local");
-    const locaisNoDeck = deck.filter(c => (c.TIPO || "").toLowerCase().includes("local"))
-      .reduce((acc, c) => acc + c.quantidade, 0);
+      const ehLocal = (carta.TIPO || "").toLowerCase().includes("local");
+      const locaisNoDeck = prev
+        .filter((c) => (c.TIPO || "").toLowerCase().includes("local"))
+        .reduce((acc, c) => acc + c.quantidade, 0);
 
-    const limite = ehLocal ? 2 : ((carta.ATRIBUTO || "").toLowerCase().includes("personagem") ? 1 : 5);
+      const limite = ehLocal
+        ? 2
+        : (carta.ATRIBUTO || "").toLowerCase().includes("personagem")
+        ? 1
+        : 5;
 
-    if (totalCartas >= 50) return;
-    if (ehLocal && locaisNoDeck >= 10) return;
+      if (totalCartas >= 50) return prev;
+      if (ehLocal && locaisNoDeck >= 10) return prev;
 
-    if (existente) {
-      if (existente.quantidade >= limite) return;
-      setDeck(deck.map(c => c.NOME === nome ? { ...c, quantidade: c.quantidade + 1 } : c));
-    } else {
-      setDeck([...deck, { ...carta, quantidade: 1 }]);
-    }
+      if (existente) {
+        if (existente.quantidade >= limite) return prev;
+        return prev.map((c) =>
+          c.NOME === nome ? { ...c, quantidade: c.quantidade + 1 } : c,
+        );
+      }
+
+      return [...prev, { ...carta, quantidade: 1 }];
+    });
   };
 
   const removerCarta = (nome) => {
-    setDeck(deck
-      .map(c => c.NOME === nome ? { ...c, quantidade: c.quantidade - 1 } : c)
-      .filter(c => c.quantidade > 0)
+    setDeck((prev) =>
+      prev
+        .map((c) =>
+          c.NOME === nome ? { ...c, quantidade: c.quantidade - 1 } : c,
+        )
+        .filter((c) => c.quantidade > 0),
     );
   };
 


### PR DESCRIPTION
## Summary
- fix state updates in `app/page.js` to avoid stale deck data

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a3cdc5e9883299e74cff3d76c11e1