### PR TITLE
Add deck tests and jest config

### DIFF
--- a/__tests__/deck.test.js
+++ b/__tests__/deck.test.js
@@ -1,0 +1,47 @@
+const { addCard, removeCard } = require('../lib/deck.cjs');
+
+describe('Deck rules', () => {
+  test('não ultrapassar 50 cartas totais', () => {
+    let deck = [];
+    // fill deck with 50 generic cards (10 names * 5 copies)
+    for (let i = 0; i < 10; i++) {
+      const card = { NOME: `carta${i}`, ATRIBUTO: 'acao', TIPO: 'acao' };
+      for (let j = 0; j < 5; j++) {
+        deck = addCard(deck, card);
+      }
+    }
+    expect(deck.reduce((sum, c) => sum + c.quantidade, 0)).toBe(50);
+    const extra = { NOME: 'extra', ATRIBUTO: 'acao', TIPO: 'acao' };
+    const updated = addCard(deck, extra);
+    expect(updated).toEqual(deck); // não adiciona
+  });
+
+  test('respeitar limites individuais', () => {
+    const personagem = { NOME: 'heroi', ATRIBUTO: 'Personagem', TIPO: 'acao' };
+    let deck = addCard([], personagem);
+    deck = addCard(deck, personagem); // tentativa acima do limite 1
+    expect(deck.find(c => c.NOME === 'heroi').quantidade).toBe(1);
+
+    const local = { NOME: 'cidade', ATRIBUTO: 'local', TIPO: 'Local' };
+    deck = addCard(deck, local);
+    deck = addCard(deck, local);
+    deck = addCard(deck, local); // limite 2
+    expect(deck.find(c => c.NOME === 'cidade').quantidade).toBe(2);
+
+    const comum = { NOME: 'magia', ATRIBUTO: 'acao', TIPO: 'acao' };
+    for (let i = 0; i < 6; i++) {
+      deck = addCard(deck, comum);
+    }
+    expect(deck.find(c => c.NOME === 'magia').quantidade).toBe(5);
+  });
+
+  test('remover cartas corretamente', () => {
+    const card = { NOME: 'teste', ATRIBUTO: 'acao', TIPO: 'acao' };
+    let deck = addCard([], card);
+    deck = addCard(deck, card);
+    deck = removeCard(deck, 'teste');
+    expect(deck.find(c => c.NOME === 'teste').quantidade).toBe(1);
+    deck = removeCard(deck, 'teste');
+    expect(deck.find(c => c.NOME === 'teste')).toBeUndefined();
+  });
+});

--- a/app/page.js
+++ b/app/page.js
@@ -2,6 +2,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { addCard, removeCard } from "../lib/deck.cjs";
 import Papa from "papaparse";
 
 export default function Home() {
@@ -26,44 +27,11 @@ export default function Home() {
   }, []);
 
   const adicionarCarta = (carta) => {
-    setDeck((prev) => {
-      const nome = carta.NOME;
-      const existente = prev.find((c) => c.NOME === nome);
-      const totalCartas = prev.reduce((acc, c) => acc + c.quantidade, 0);
-
-      const ehLocal = (carta.TIPO || "").toLowerCase().includes("local");
-      const locaisNoDeck = prev
-        .filter((c) => (c.TIPO || "").toLowerCase().includes("local"))
-        .reduce((acc, c) => acc + c.quantidade, 0);
-
-      const limite = ehLocal
-        ? 2
-        : (carta.ATRIBUTO || "").toLowerCase().includes("personagem")
-        ? 1
-        : 5;
-
-      if (totalCartas >= 50) return prev;
-      if (ehLocal && locaisNoDeck >= 10) return prev;
-
-      if (existente) {
-        if (existente.quantidade >= limite) return prev;
-        return prev.map((c) =>
-          c.NOME === nome ? { ...c, quantidade: c.quantidade + 1 } : c,
-        );
-      }
-
-      return [...prev, { ...carta, quantidade: 1 }];
-    });
+    setDeck((prev) => addCard(prev, carta));
   };
 
   const removerCarta = (nome) => {
-    setDeck((prev) =>
-      prev
-        .map((c) =>
-          c.NOME === nome ? { ...c, quantidade: c.quantidade - 1 } : c,
-        )
-        .filter((c) => c.quantidade > 0),
-    );
+    setDeck((prev) => removeCard(prev, nome));
   };
 
   const cartas = abaAtiva === "locais" ? cartasLocais : cartasNaoLocais;

--- a/lib/deck.cjs
+++ b/lib/deck.cjs
@@ -1,0 +1,38 @@
+function addCard(deck, card) {
+  const nome = card.NOME;
+  const existente = deck.find((c) => c.NOME === nome);
+  const totalCartas = deck.reduce((acc, c) => acc + c.quantidade, 0);
+
+  const ehLocal = (card.TIPO || "").toLowerCase().includes("local");
+  const locaisNoDeck = deck
+    .filter((c) => (c.TIPO || "").toLowerCase().includes("local"))
+    .reduce((acc, c) => acc + c.quantidade, 0);
+
+  const limite = ehLocal
+    ? 2
+    : (card.ATRIBUTO || "").toLowerCase().includes("personagem")
+    ? 1
+    : 5;
+
+  if (totalCartas >= 50) return deck;
+  if (ehLocal && locaisNoDeck >= 10) return deck;
+
+  if (existente) {
+    if (existente.quantidade >= limite) return deck;
+    return deck.map((c) =>
+      c.NOME === nome ? { ...c, quantidade: c.quantidade + 1 } : c
+    );
+  }
+
+  return [...deck, { ...card, quantidade: 1 }];
+}
+
+function removeCard(deck, nome) {
+  return deck
+    .map((c) =>
+      c.NOME === nome ? { ...c, quantidade: c.quantidade - 1 } : c
+    )
+    .filter((c) => c.quantidade > 0);
+}
+
+module.exports = { addCard, removeCard };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "next": "15.3.1",
@@ -16,6 +17,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4"
+    "tailwindcss": "^4",
+    "jest": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- extract deck manipulation logic into `lib/deck.cjs`
- update `page.js` to use the new helpers
- add jest configuration and tests covering deck limits and removal

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a3e4b58cc8329855778a3fb3e4d57